### PR TITLE
Upgrade to TensorFlow 2.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,11 @@
 Please click on the image for a [high-res version](https://compvis.github.io/adaptive-style-transfer/images/adaptive-style-transfer_chart.jpg).
 
 ## Requirements
-- python 2.7
-- tensorflow 1.2.
+- Python 3.10+
+- TensorFlow 2.16.1 (GPU build requires CUDA 12.4 and NVIDIA driver 550.54.14 or newer)
+- tf_slim
 - PIL, numpy, scipy
 - tqdm
-
-*Also tested in `python3.6 + tensorflow 1.12.0`*
 
 ## Inference 
 #### Simplest van Gogh example

--- a/evaluation/feature_extractor/feature_extractor.py
+++ b/evaluation/feature_extractor/feature_extractor.py
@@ -17,8 +17,9 @@
 
 import numpy as np
 import sklearn.preprocessing
-import tensorflow as tf
-import tensorflow.contrib.slim as slim
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
+import tf_slim as slim
 from tensorflow.python import pywrap_tensorflow
 
 from features import extract_features
@@ -113,7 +114,7 @@ class SlimFeatureExtractor(object):
                 self.MaxPool_0a_7x7 = tf.get_default_graph().get_tensor_by_name("InceptionV1/Logits/MaxPool_0a_7x7/AvgPool:0")
             elif net_name in ['vgg_16', 'vgg_16_multihead']:
                 for layer_name in ['fc6', 'fc7'] + \
-                        ['conv{0}/conv{0}_{1}'.format(i, j) for i in xrange(3, 6) for j in xrange(1, 4)]:
+                        ['conv{0}/conv{0}_{1}'.format(i, j) for i in range(3, 6) for j in range(1, 4)]:
                     self.__dict__['vgg_16/{}_prerelu'.format(layer_name)] = \
                         tf.get_default_graph().get_tensor_by_name("vgg_16/{}/BiasAdd:0".format(layer_name))
             config = tf.ConfigProto(gpu_options=

--- a/evaluation/feature_extractor/features.py
+++ b/evaluation/feature_extractor/features.py
@@ -21,7 +21,8 @@ import os.path
 from os.path import join
 import time
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 import numpy as np
 import scipy.stats.mstats as stat
 import scipy.spatial.distance as spdis
@@ -114,7 +115,7 @@ def extract_features(flipped, net=None, frame_ids=None, layer_names=None,
 
     tensors_to_get = [net.__getattribute__(name) for name in layer_names]
     if verbose >= 2:
-        print 'Tensors to extract:', tensors_to_get
+        print('Tensors to extract:', tensors_to_get)
     d = dict()
     if frame_ids is None:
         if hasattr(image_getter, 'total_num_images'):
@@ -135,7 +136,7 @@ def extract_features(flipped, net=None, frame_ids=None, layer_names=None,
     else:
         num_batches = int(math.ceil(len(frame_ids) / batch_size))
         if verbose >= 2:
-            print 'Running {} iterations with batch_size={}'.format(num_batches, batch_size)
+            print('Running {} iterations with batch_size={}'.format(num_batches, batch_size))
         for step, batch_start in tqdm(enumerate(range(0, len(frame_ids), batch_size)),
                                       total=num_batches, disable=(verbose == 0)):
             batch_idxs = frame_ids[batch_start:batch_start + batch_size]
@@ -183,7 +184,7 @@ def extract_features_from_batch_iterator(net, batch_iterator, tensors_to_get,
     Returns: out_features_dict
     """
     if verbose >= 2:
-        print 'Running {} iterations (from batch_iterator)'.format(len(batch_iterator))
+        print('Running {} iterations (from batch_iterator)'.format(len(batch_iterator)))
     for step, batch in tqdm(enumerate(batch_iterator), total=len(batch_iterator), disable=(verbose == 0)):
 
         feed_dict = {input_pl_name + ':0': batch}

--- a/evaluation/feature_extractor/image_getter.py
+++ b/evaluation/feature_extractor/image_getter.py
@@ -61,7 +61,7 @@ class ImageGetterFromMat:
 
         if resize_shape is not None:
             resized_batch = np.zeros((batch.shape[0],) + resize_shape + (3,), dtype=np.float32)
-            for i in xrange(batch.shape[0]):
+            for i in range(batch.shape[0]):
                 image = np.asarray(
                     Image.fromarray(batch[i, ...]).resize(resize_shape, PIL.Image.ANTIALIAS))
                 resized_batch[i, ...] = image

--- a/evaluation/feature_extractor/nets/nets_factory.py
+++ b/evaluation/feature_extractor/nets/nets_factory.py
@@ -19,10 +19,11 @@ from __future__ import print_function
 
 import functools
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 import vgg
 
-slim = tf.contrib.slim
+import tf_slim as slim
 
 networks_map = {
                 'vgg_a': vgg.vgg_a,

--- a/evaluation/feature_extractor/nets/vgg.py
+++ b/evaluation/feature_extractor/nets/vgg.py
@@ -43,9 +43,10 @@ from __future__ import print_function
 
 import collections
 from pprint import pformat
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 
-import tensorflow.contrib.slim as slim
+import tf_slim as slim
 
 
 def vgg_arg_scope(weight_decay=0.0005):

--- a/evaluation/feature_extractor/preprocessing/preprocessing_factory.py
+++ b/evaluation/feature_extractor/preprocessing/preprocessing_factory.py
@@ -17,11 +17,7 @@
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
-
 import vgg_preprocessing
-
-slim = tf.contrib.slim
 
 
 def get_preprocessing(name, is_training=False):

--- a/evaluation/feature_extractor/preprocessing/vgg_preprocessing.py
+++ b/evaluation/feature_extractor/preprocessing/vgg_preprocessing.py
@@ -32,11 +32,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 
 from tensorflow.python.ops import control_flow_ops
-
-slim = tf.contrib.slim
 
 _R_MEAN = 123.68
 _G_MEAN = 116.78

--- a/main.py
+++ b/main.py
@@ -16,7 +16,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import argparse
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 tf.set_random_seed(228)
 from model import Artgan
 

--- a/model.py
+++ b/model.py
@@ -21,7 +21,8 @@ from __future__ import print_function
 import os
 import time
 from glob import glob
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 import numpy as np
 from collections import namedtuple
 from tqdm import tqdm

--- a/module.py
+++ b/module.py
@@ -16,6 +16,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import division
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 from ops import *
 
 

--- a/ops.py
+++ b/ops.py
@@ -17,12 +17,13 @@
 
 import math
 import numpy as np
-import tensorflow as tf
-import tensorflow.contrib.slim as slim
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
+import tf_slim as slim
 from tensorflow.python.framework import ops
 import cv2
 
-import tensorflow.contrib.layers as tflayers
+from tf_slim import layers as tflayers
 
 from utils import *
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+tensorflow==2.16.1
+tf_slim>=1.1.0


### PR DESCRIPTION
## Summary
- migrate core modules to TensorFlow 2.16 using `tf.compat.v1`
- replace deprecated `tf.contrib` with `tf_slim` and update evaluation utilities for Python 3
- document CUDA 12.4 / driver 550.54.14 requirement and add `requirements.txt`

## Testing
- `pytest`
- `python - <<'PY'
import tensorflow as tf
print(tf.__version__)
print('GPU devices:', tf.config.list_physical_devices('GPU'))
PY`

------
https://chatgpt.com/codex/tasks/task_b_689e5dfdb9c4832e9781b334fd511140